### PR TITLE
Added missing styleMapFamilyName and styleMapStyleName attributes for style grouping

### DIFF
--- a/sources/_Literata-Italic.designspace
+++ b/sources/_Literata-Italic.designspace
@@ -116,7 +116,7 @@
     </source>
   </sources>
   <instances>
-    <instance name="Literata 7pt Italic" familyname="Literata" stylename="7pt Italic" filename="instance_ufo/Literata-7ptItalic.ufo">
+    <instance name="Literata 7pt Italic" familyname="Literata" stylename="7pt Italic" stylemapfamilyname="7pt Regular" stylemapstylename="italic" filename="instance_ufo/Literata-7ptItalic.ufo">
       <location>
         <dimension name="Weight" xvalue="400"/>
         <dimension name="Optical size" xvalue="6"/>
@@ -141,7 +141,15 @@
         </dict>
       </lib>
     </instance>
-    <instance name="Literata 7pt SemiBold Italic" familyname="Literata" stylename="7pt SemiBold Italic" filename="instance_ufo/Literata-7ptSemiBoldItalic.ufo">
+    <instance name="Literata 7pt Medium Italic" familyname="Literata" stylename="7pt Medium Italic" stylemapfamilyname="7pt Medium" stylemapstylename="italic" filename="instance_ufo/Literata-7ptMediumItalic.ufo">
+      <location>
+        <dimension name="Weight" xvalue="480"/>
+        <dimension name="Optical size" xvalue="6"/>
+      </location>
+      <kerning/>
+      <info/>
+    </instance>
+    <instance name="Literata 7pt SemiBold Italic" familyname="Literata" stylename="7pt SemiBold Italic" stylemapfamilyname="7pt SemiBold" stylemapstylename="italic" filename="instance_ufo/Literata-7ptSemiBoldItalic.ufo">
       <location>
         <dimension name="Weight" xvalue="550"/>
         <dimension name="Optical size" xvalue="6"/>
@@ -168,7 +176,7 @@
         </dict>
       </lib>
     </instance>
-    <instance name="Literata 7pt Bold Italic" familyname="Literata" stylename="7pt Bold Italic" filename="instance_ufo/Literata-7ptBoldItalic.ufo">
+    <instance name="Literata 7pt Bold Italic" familyname="Literata" stylename="7pt Bold Italic" stylemapfamilyname="7pt Regular" stylemapstylename="bold italic" filename="instance_ufo/Literata-7ptBoldItalic.ufo">
       <location>
         <dimension name="Weight" xvalue="650"/>
         <dimension name="Optical size" xvalue="6"/>
@@ -195,7 +203,7 @@
         </dict>
       </lib>
     </instance>
-    <instance name="Literata 12pt Light Italic" familyname="Literata" stylename="12pt Light Italic" filename="instance_ufo/Literata-12ptLightItalic.ufo">
+    <instance name="Literata 12pt Light Italic" familyname="Literata" stylename="12pt Light Italic" stylemapfamilyname="12pt Light" stylemapstylename="italic" filename="instance_ufo/Literata-12ptLightItalic.ufo">
       <location>
         <dimension name="Weight" xvalue="300"/>
         <dimension name="Optical size" xvalue="10"/>
@@ -222,7 +230,7 @@
         </dict>
       </lib>
     </instance>
-    <instance name="Literata 12pt Italic" familyname="Literata" stylename="12pt Italic" filename="instance_ufo/Literata-12ptItalic.ufo">
+    <instance name="Literata 12pt Italic" familyname="Literata" stylename="12pt Italic" stylemapfamilyname="12pt Regular" stylemapstylename="italic" filename="instance_ufo/Literata-12ptItalic.ufo">
       <location>
         <dimension name="Weight" xvalue="400"/>
         <dimension name="Optical size" xvalue="10"/>
@@ -247,7 +255,7 @@
         </dict>
       </lib>
     </instance>
-    <instance name="Literata 12pt Medium Italic" familyname="Literata" stylename="12pt Medium Italic" filename="instance_ufo/Literata-12ptMediumItalic.ufo">
+    <instance name="Literata 12pt Medium Italic" familyname="Literata" stylename="12pt Medium Italic" stylemapfamilyname="12pt Medium" stylemapstylename="italic" filename="instance_ufo/Literata-12ptMediumItalic.ufo">
       <location>
         <dimension name="Weight" xvalue="480"/>
         <dimension name="Optical size" xvalue="10"/>
@@ -274,7 +282,7 @@
         </dict>
       </lib>
     </instance>
-    <instance name="Literata 12pt SemiBold Italic" familyname="Literata" stylename="12pt SemiBold Italic" filename="instance_ufo/Literata-12ptSemiBoldItalic.ufo">
+    <instance name="Literata 12pt SemiBold Italic" familyname="Literata" stylename="12pt SemiBold Italic" stylemapfamilyname="12pt SemiBold" stylemapstylename="italic" filename="instance_ufo/Literata-12ptSemiBoldItalic.ufo">
       <location>
         <dimension name="Weight" xvalue="550"/>
         <dimension name="Optical size" xvalue="10"/>
@@ -301,7 +309,7 @@
         </dict>
       </lib>
     </instance>
-    <instance name="Literata 12pt Bold Italic" familyname="Literata" stylename="12pt Bold Italic" filename="instance_ufo/Literata-12ptBoldItalic.ufo">
+    <instance name="Literata 12pt Bold Italic" familyname="Literata" stylename="12pt Bold Italic" stylemapfamilyname="12pt Regular" stylemapstylename="bold italic" filename="instance_ufo/Literata-12ptBoldItalic.ufo">
       <location>
         <dimension name="Weight" xvalue="650"/>
         <dimension name="Optical size" xvalue="10"/>
@@ -328,7 +336,7 @@
         </dict>
       </lib>
     </instance>
-    <instance name="Literata 12pt ExtraBold Italic" familyname="Literata" stylename="12pt ExtraBold Italic" filename="instance_ufo/Literata-12ptExtraBoldItalic.ufo">
+    <instance name="Literata 12pt ExtraBold Italic" familyname="Literata" stylename="12pt ExtraBold Italic" stylemapfamilyname="12pt ExtraBold" stylemapstylename="italic" filename="instance_ufo/Literata-12ptExtraBoldItalic.ufo">
       <location>
         <dimension name="Weight" xvalue="800"/>
         <dimension name="Optical size" xvalue="10"/>
@@ -355,7 +363,7 @@
         </dict>
       </lib>
     </instance>
-    <instance name="Literata 36pt Light Italic" familyname="Literata" stylename="36pt Light Italic" filename="instance_ufo/Literata-36ptLightItalic.ufo">
+    <instance name="Literata 36pt Light Italic" familyname="Literata" stylename="36pt Light Italic" stylemapfamilyname="36pt Light" stylemapstylename="italic" filename="instance_ufo/Literata-36ptLightItalic.ufo">
       <location>
         <dimension name="Weight" xvalue="300"/>
         <dimension name="Optical size" xvalue="55"/>
@@ -386,7 +394,7 @@
         </dict>
       </lib>
     </instance>
-    <instance name="Literata 36pt Italic" familyname="Literata" stylename="36pt Italic" filename="instance_ufo/Literata-36ptItalic.ufo">
+    <instance name="Literata 36pt Italic" familyname="Literata" stylename="36pt Italic" stylemapfamilyname="36pt Regular" stylemapstylename="italic" filename="instance_ufo/Literata-36ptItalic.ufo">
       <location>
         <dimension name="Weight" xvalue="400"/>
         <dimension name="Optical size" xvalue="55"/>
@@ -413,7 +421,15 @@
         </dict>
       </lib>
     </instance>
-    <instance name="Literata 36pt SemiBold Italic" familyname="Literata" stylename="36pt SemiBold Italic" filename="instance_ufo/Literata-36ptSemiBoldItalic.ufo">
+    <instance name="Literata 36pt Medium Italic" familyname="Literata" stylename="36pt Medium Italic" stylemapfamilyname="36pt Medium" stylemapstylename="italic" filename="instance_ufo/Literata-36ptMediumItalic.ufo">
+      <location>
+        <dimension name="Weight" xvalue="480"/>
+        <dimension name="Optical size" xvalue="55"/>
+      </location>
+      <kerning/>
+      <info/>
+    </instance>
+    <instance name="Literata 36pt SemiBold Italic" familyname="Literata" stylename="36pt SemiBold Italic" stylemapfamilyname="36pt SemiBold" stylemapstylename="italic" filename="instance_ufo/Literata-36ptSemiBoldItalic.ufo">
       <location>
         <dimension name="Weight" xvalue="550"/>
         <dimension name="Optical size" xvalue="55"/>
@@ -444,7 +460,7 @@
         </dict>
       </lib>
     </instance>
-    <instance name="Literata 36pt Bold Italic" familyname="Literata" stylename="36pt Bold Italic" filename="instance_ufo/Literata-36ptBoldItalic.ufo">
+    <instance name="Literata 36pt Bold Italic" familyname="Literata" stylename="36pt Bold Italic" stylemapfamilyname="36pt Regular" stylemapstylename="bold italic" filename="instance_ufo/Literata-36ptBoldItalic.ufo">
       <location>
         <dimension name="Weight" xvalue="650"/>
         <dimension name="Optical size" xvalue="55"/>
@@ -475,7 +491,7 @@
         </dict>
       </lib>
     </instance>
-    <instance name="Literata 36pt ExtraBold Italic" familyname="Literata" stylename="36pt ExtraBold Italic" filename="instance_ufo/Literata-36ptExtraBoldItalic.ufo">
+    <instance name="Literata 36pt ExtraBold Italic" familyname="Literata" stylename="36pt ExtraBold Italic" stylemapfamilyname="36pt ExtraBold" stylemapstylename="italic" filename="instance_ufo/Literata-36ptExtraBoldItalic.ufo">
       <location>
         <dimension name="Weight" xvalue="800"/>
         <dimension name="Optical size" xvalue="55"/>
@@ -506,7 +522,7 @@
         </dict>
       </lib>
     </instance>
-    <instance name="Literata 72pt ExtraLight Italic" familyname="Literata" stylename="72pt ExtraLight Italic" filename="instance_ufo/Literata-72ptExtraLightItalic.ufo">
+    <instance name="Literata 72pt ExtraLight Italic" familyname="Literata" stylename="72pt ExtraLight Italic" stylemapfamilyname="72pt ExtraLight" stylemapstylename="italic" filename="instance_ufo/Literata-72ptExtraLightItalic.ufo">
       <location>
         <dimension name="Weight" xvalue="200"/>
         <dimension name="Optical size" xvalue="144"/>
@@ -531,7 +547,7 @@
         </dict>
       </lib>
     </instance>
-    <instance name="Literata 72pt Light Italic" familyname="Literata" stylename="72pt Light Italic" filename="instance_ufo/Literata-72ptLightItalic.ufo">
+    <instance name="Literata 72pt Light Italic" familyname="Literata" stylename="72pt Light Italic" stylemapfamilyname="72pt Light" stylemapstylename="italic" filename="instance_ufo/Literata-72ptLightItalic.ufo">
       <location>
         <dimension name="Weight" xvalue="300"/>
         <dimension name="Optical size" xvalue="144"/>
@@ -558,7 +574,7 @@
         </dict>
       </lib>
     </instance>
-    <instance name="Literata 72pt Italic" familyname="Literata" stylename="72pt Italic" filename="instance_ufo/Literata-72ptItalic.ufo">
+    <instance name="Literata 72pt Italic" familyname="Literata" stylename="72pt Italic" stylemapfamilyname="72pt Regular" stylemapstylename="italic" filename="instance_ufo/Literata-72ptItalic.ufo">
       <location>
         <dimension name="Weight" xvalue="400"/>
         <dimension name="Optical size" xvalue="144"/>
@@ -583,7 +599,15 @@
         </dict>
       </lib>
     </instance>
-    <instance name="Literata 72pt SemiBold Italic" familyname="Literata" stylename="72pt SemiBold Italic" filename="instance_ufo/Literata-72ptSemiBoldItalic.ufo">
+    <instance name="Literata 72pt Medium Italic" familyname="Literata" stylename="72pt Medium Italic" stylemapfamilyname="72pt Medium" stylemapstylename="italic" filename="instance_ufo/Literata-72ptMediumItalic.ufo">
+      <location>
+        <dimension name="Weight" xvalue="480"/>
+        <dimension name="Optical size" xvalue="144"/>
+      </location>
+      <kerning/>
+      <info/>
+    </instance>
+    <instance name="Literata 72pt SemiBold Italic" familyname="Literata" stylename="72pt SemiBold Italic" stylemapfamilyname="72pt SemiBold" stylemapstylename="italic" filename="instance_ufo/Literata-72ptSemiBoldItalic.ufo">
       <location>
         <dimension name="Weight" xvalue="550"/>
         <dimension name="Optical size" xvalue="144"/>
@@ -610,7 +634,7 @@
         </dict>
       </lib>
     </instance>
-    <instance name="Literata 72pt Bold Italic" familyname="Literata" stylename="72pt Bold Italic" filename="instance_ufo/Literata-72ptBoldItalic.ufo">
+    <instance name="Literata 72pt Bold Italic" familyname="Literata" stylename="72pt Bold Italic" stylemapfamilyname="72pt Regular" stylemapstylename="bold italic" filename="instance_ufo/Literata-72ptBoldItalic.ufo">
       <location>
         <dimension name="Weight" xvalue="650"/>
         <dimension name="Optical size" xvalue="144"/>
@@ -637,7 +661,7 @@
         </dict>
       </lib>
     </instance>
-    <instance name="Literata 72pt ExtraBold Italic" familyname="Literata" stylename="72pt ExtraBold Italic" filename="instance_ufo/Literata-72ptExtraBoldItalic.ufo">
+    <instance name="Literata 72pt ExtraBold Italic" familyname="Literata" stylename="72pt ExtraBold Italic" stylemapfamilyname="72pt ExtraBold" stylemapstylename="italic" filename="instance_ufo/Literata-72ptExtraBoldItalic.ufo">
       <location>
         <dimension name="Weight" xvalue="800"/>
         <dimension name="Optical size" xvalue="144"/>
@@ -664,7 +688,7 @@
         </dict>
       </lib>
     </instance>
-    <instance name="Literata 72pt Black Italic" familyname="Literata" stylename="72pt Black Italic" filename="instance_ufo/Literata-72ptBlackItalic.ufo">
+    <instance name="Literata 72pt Black Italic" familyname="Literata" stylename="72pt Black Italic" stylemapfamilyname="72pt Black" stylemapstylename="italic" filename="instance_ufo/Literata-72ptBlackItalic.ufo">
       <location>
         <dimension name="Weight" xvalue="900"/>
         <dimension name="Optical size" xvalue="144"/>
@@ -688,30 +712,6 @@
           <string>Medium (normal)</string>
         </dict>
       </lib>
-    </instance>
-    <instance name="Literata 7pt SemiBold Italic" familyname="Literata" stylename="7pt Medium Italic" filename="instance_ufo/Literata-7ptMediumItalic.ufo">
-      <location>
-        <dimension name="Weight" xvalue="480"/>
-        <dimension name="Optical size" xvalue="6"/>
-      </location>
-      <kerning/>
-      <info/>
-    </instance>
-    <instance name="Literata 36pt SemiBold Italic" familyname="Literata" stylename="36pt Medium Italic" filename="instance_ufo/Literata-36ptMediumItalic.ufo">
-      <location>
-        <dimension name="Weight" xvalue="480"/>
-        <dimension name="Optical size" xvalue="55"/>
-      </location>
-      <kerning/>
-      <info/>
-    </instance>
-    <instance name="Literata 72pt SemiBold Italic" familyname="Literata" stylename="72pt Medium Italic" filename="instance_ufo/Literata-72ptMediumItalic.ufo">
-      <location>
-        <dimension name="Weight" xvalue="480"/>
-        <dimension name="Optical size" xvalue="144"/>
-      </location>
-      <kerning/>
-      <info/>
     </instance>
   </instances>
   <lib>

--- a/sources/_Literata-Upright.designspace
+++ b/sources/_Literata-Upright.designspace
@@ -104,7 +104,7 @@
     </source>
   </sources>
   <instances>
-    <instance name="Literata 7pt Regular" familyname="Literata" stylename="7pt Regular" filename="instance_ufo/Literata-7ptRegular.ufo">
+    <instance name="Literata 7pt Regular" familyname="Literata" stylename="7pt Regular" stylemapfamilyname="7pt Regular" stylemapstylename="regular" filename="instance_ufo/Literata-7ptRegular.ufo">
       <location>
         <dimension name="Weight" xvalue="400"/>
         <dimension name="Optical size" xvalue="6"/>
@@ -129,7 +129,15 @@
         </dict>
       </lib>
     </instance>
-    <instance name="Literata 7pt SemiBold" familyname="Literata" stylename="7pt SemiBold" filename="instance_ufo/Literata-7ptSemiBold.ufo">
+    <instance name="Literata 7pt Medium" familyname="Literata" stylename="7pt Medium" stylemapfamilyname="7pt Medium" stylemapstylename="regular" filename="instance_ufo/Literata-7ptMedium.ufo">
+      <location>
+        <dimension name="Weight" xvalue="480"/>
+        <dimension name="Optical size" xvalue="6"/>
+      </location>
+      <kerning/>
+      <info/>
+    </instance>
+    <instance name="Literata 7pt SemiBold" familyname="Literata" stylename="7pt SemiBold" stylemapfamilyname="7pt SemiBold" stylemapstylename="regular" filename="instance_ufo/Literata-7ptSemiBold.ufo">
       <location>
         <dimension name="Weight" xvalue="550"/>
         <dimension name="Optical size" xvalue="6"/>
@@ -156,7 +164,7 @@
         </dict>
       </lib>
     </instance>
-    <instance name="Literata 7pt Bold" familyname="Literata" stylename="7pt Bold" filename="instance_ufo/Literata-7ptBold.ufo">
+    <instance name="Literata 7pt Bold" familyname="Literata" stylename="7pt Bold" stylemapfamilyname="7pt Regular" stylemapstylename="bold" filename="instance_ufo/Literata-7ptBold.ufo">
       <location>
         <dimension name="Weight" xvalue="650"/>
         <dimension name="Optical size" xvalue="6"/>
@@ -183,7 +191,7 @@
         </dict>
       </lib>
     </instance>
-    <instance name="Literata 12pt Light" familyname="Literata" stylename="12pt Light" filename="instance_ufo/Literata-12ptLight.ufo">
+    <instance name="Literata 12pt Light" familyname="Literata" stylename="12pt Light" stylemapfamilyname="12pt Light" stylemapstylename="regular" filename="instance_ufo/Literata-12ptLight.ufo">
       <location>
         <dimension name="Weight" xvalue="300"/>
         <dimension name="Optical size" xvalue="10"/>
@@ -210,7 +218,7 @@
         </dict>
       </lib>
     </instance>
-    <instance name="Literata 12pt Regular" familyname="Literata" stylename="12pt Regular" filename="instance_ufo/Literata-12ptRegular.ufo">
+    <instance name="Literata 12pt Regular" familyname="Literata" stylename="12pt Regular" stylemapfamilyname="12pt Regular" stylemapstylename="regular" filename="instance_ufo/Literata-12ptRegular.ufo">
       <location>
         <dimension name="Weight" xvalue="400"/>
         <dimension name="Optical size" xvalue="10"/>
@@ -235,7 +243,7 @@
         </dict>
       </lib>
     </instance>
-    <instance name="Literata 12pt Medium" familyname="Literata" stylename="12pt Medium" filename="instance_ufo/Literata-12ptMedium.ufo">
+    <instance name="Literata 12pt Medium" familyname="Literata" stylename="12pt Medium" stylemapfamilyname="12pt Medium" stylemapstylename="regular" filename="instance_ufo/Literata-12ptMedium.ufo">
       <location>
         <dimension name="Weight" xvalue="480"/>
         <dimension name="Optical size" xvalue="10"/>
@@ -262,7 +270,7 @@
         </dict>
       </lib>
     </instance>
-    <instance name="Literata 12pt SemiBold" familyname="Literata" stylename="12pt SemiBold" filename="instance_ufo/Literata-12ptSemiBold.ufo">
+    <instance name="Literata 12pt SemiBold" familyname="Literata" stylename="12pt SemiBold" stylemapfamilyname="12pt SemiBold" stylemapstylename="regular" filename="instance_ufo/Literata-12ptSemiBold.ufo">
       <location>
         <dimension name="Weight" xvalue="550"/>
         <dimension name="Optical size" xvalue="10"/>
@@ -289,7 +297,7 @@
         </dict>
       </lib>
     </instance>
-    <instance name="Literata 12pt Bold" familyname="Literata" stylename="12pt Bold" filename="instance_ufo/Literata-12ptBold.ufo">
+    <instance name="Literata 12pt Bold" familyname="Literata" stylename="12pt Bold" stylemapfamilyname="12pt Regular" stylemapstylename="bold" filename="instance_ufo/Literata-12ptBold.ufo">
       <location>
         <dimension name="Weight" xvalue="650"/>
         <dimension name="Optical size" xvalue="10"/>
@@ -316,7 +324,7 @@
         </dict>
       </lib>
     </instance>
-    <instance name="Literata 12pt ExtraBold" familyname="Literata" stylename="12pt ExtraBold" filename="instance_ufo/Literata-12ptExtraBold.ufo">
+    <instance name="Literata 12pt ExtraBold" familyname="Literata" stylename="12pt ExtraBold" stylemapfamilyname="12pt ExtraBold" stylemapstylename="regular" filename="instance_ufo/Literata-12ptExtraBold.ufo">
       <location>
         <dimension name="Weight" xvalue="800"/>
         <dimension name="Optical size" xvalue="10"/>
@@ -343,7 +351,7 @@
         </dict>
       </lib>
     </instance>
-    <instance name="Literata 36pt Light" familyname="Literata" stylename="36pt Light" filename="instance_ufo/Literata-36ptLight.ufo">
+    <instance name="Literata 36pt Light" familyname="Literata" stylename="36pt Light" stylemapfamilyname="36pt Light" stylemapstylename="regular" filename="instance_ufo/Literata-36ptLight.ufo">
       <location>
         <dimension name="Weight" xvalue="300"/>
         <dimension name="Optical size" xvalue="55"/>
@@ -374,7 +382,7 @@
         </dict>
       </lib>
     </instance>
-    <instance name="Literata 36pt Regular" familyname="Literata" stylename="36pt Regular" filename="instance_ufo/Literata-36ptRegular.ufo">
+    <instance name="Literata 36pt Regular" familyname="Literata" stylename="36pt Regular" stylemapfamilyname="36pt Regular" stylemapstylename="regular" filename="instance_ufo/Literata-36ptRegular.ufo">
       <location>
         <dimension name="Weight" xvalue="400"/>
         <dimension name="Optical size" xvalue="55"/>
@@ -401,7 +409,15 @@
         </dict>
       </lib>
     </instance>
-    <instance name="Literata 36pt SemiBold" familyname="Literata" stylename="36pt SemiBold" filename="instance_ufo/Literata-36ptSemiBold.ufo">
+    <instance name="Literata 36pt Medium" familyname="Literata" stylename="36pt Medium" stylemapfamilyname="36pt Medium" stylemapstylename="regular" filename="instance_ufo/Literata-36ptMedium.ufo">
+      <location>
+        <dimension name="Weight" xvalue="480"/>
+        <dimension name="Optical size" xvalue="55"/>
+      </location>
+      <kerning/>
+      <info/>
+    </instance>
+    <instance name="Literata 36pt SemiBold" familyname="Literata" stylename="36pt SemiBold" stylemapfamilyname="36pt SemiBold" stylemapstylename="regular" filename="instance_ufo/Literata-36ptSemiBold.ufo">
       <location>
         <dimension name="Weight" xvalue="550"/>
         <dimension name="Optical size" xvalue="55"/>
@@ -432,7 +448,7 @@
         </dict>
       </lib>
     </instance>
-    <instance name="Literata 36pt Bold" familyname="Literata" stylename="36pt Bold" filename="instance_ufo/Literata-36ptBold.ufo">
+    <instance name="Literata 36pt Bold" familyname="Literata" stylename="36pt Bold" stylemapfamilyname="36pt Regular" stylemapstylename="bold" filename="instance_ufo/Literata-36ptBold.ufo">
       <location>
         <dimension name="Weight" xvalue="650"/>
         <dimension name="Optical size" xvalue="55"/>
@@ -463,7 +479,7 @@
         </dict>
       </lib>
     </instance>
-    <instance name="Literata 36pt ExtraBold" familyname="Literata" stylename="36pt ExtraBold" filename="instance_ufo/Literata-36ptExtraBold.ufo">
+    <instance name="Literata 36pt ExtraBold" familyname="Literata" stylename="36pt ExtraBold" stylemapfamilyname="36pt ExtraBold" stylemapstylename="regular" filename="instance_ufo/Literata-36ptExtraBold.ufo">
       <location>
         <dimension name="Weight" xvalue="800"/>
         <dimension name="Optical size" xvalue="55"/>
@@ -494,7 +510,7 @@
         </dict>
       </lib>
     </instance>
-    <instance name="Literata 72pt ExtraLight" familyname="Literata" stylename="72pt ExtraLight" filename="instance_ufo/Literata-72ptExtraLight.ufo">
+    <instance name="Literata 72pt ExtraLight" familyname="Literata" stylename="72pt ExtraLight" stylemapfamilyname="72pt ExtraLight" stylemapstylename="regular" filename="instance_ufo/Literata-72ptExtraLight.ufo">
       <location>
         <dimension name="Weight" xvalue="200"/>
         <dimension name="Optical size" xvalue="144"/>
@@ -519,7 +535,7 @@
         </dict>
       </lib>
     </instance>
-    <instance name="Literata 72pt Light" familyname="Literata" stylename="72pt Light" filename="instance_ufo/Literata-72ptLight.ufo">
+    <instance name="Literata 72pt Light" familyname="Literata" stylename="72pt Light" stylemapfamilyname="72pt Light" stylemapstylename="regular" filename="instance_ufo/Literata-72ptLight.ufo">
       <location>
         <dimension name="Weight" xvalue="300"/>
         <dimension name="Optical size" xvalue="144"/>
@@ -546,7 +562,7 @@
         </dict>
       </lib>
     </instance>
-    <instance name="Literata 72pt Regular" familyname="Literata" stylename="72pt Regular" filename="instance_ufo/Literata-72ptRegular.ufo">
+    <instance name="Literata 72pt Regular" familyname="Literata" stylename="72pt Regular" stylemapfamilyname="72pt Regular" stylemapstylename="regular" filename="instance_ufo/Literata-72ptRegular.ufo">
       <location>
         <dimension name="Weight" xvalue="400"/>
         <dimension name="Optical size" xvalue="144"/>
@@ -571,7 +587,15 @@
         </dict>
       </lib>
     </instance>
-    <instance name="Literata 72pt SemiBold" familyname="Literata" stylename="72pt SemiBold" filename="instance_ufo/Literata-72ptSemiBold.ufo">
+    <instance name="Literata 72pt Medium" familyname="Literata" stylename="72pt Medium" stylemapfamilyname="72pt Medium" stylemapstylename="regular" filename="instance_ufo/Literata-72ptMedium.ufo">
+      <location>
+        <dimension name="Weight" xvalue="480"/>
+        <dimension name="Optical size" xvalue="144"/>
+      </location>
+      <kerning/>
+      <info/>
+    </instance>
+    <instance name="Literata 72pt SemiBold" familyname="Literata" stylename="72pt SemiBold" stylemapfamilyname="72pt SemiBold" stylemapstylename="regular" filename="instance_ufo/Literata-72ptSemiBold.ufo">
       <location>
         <dimension name="Weight" xvalue="550"/>
         <dimension name="Optical size" xvalue="144"/>
@@ -598,7 +622,7 @@
         </dict>
       </lib>
     </instance>
-    <instance name="Literata 72pt Bold" familyname="Literata" stylename="72pt Bold" filename="instance_ufo/Literata-72ptBold.ufo">
+    <instance name="Literata 72pt Bold" familyname="Literata" stylename="72pt Bold" stylemapfamilyname="72pt Regular" stylemapstylename="bold" filename="instance_ufo/Literata-72ptBold.ufo">
       <location>
         <dimension name="Weight" xvalue="650"/>
         <dimension name="Optical size" xvalue="144"/>
@@ -625,7 +649,7 @@
         </dict>
       </lib>
     </instance>
-    <instance name="Literata 72pt ExtraBold" familyname="Literata" stylename="72pt ExtraBold" filename="instance_ufo/Literata-72ptExtraBold.ufo">
+    <instance name="Literata 72pt ExtraBold" familyname="Literata" stylename="72pt ExtraBold" stylemapfamilyname="72pt ExtraBold" stylemapstylename="regular" filename="instance_ufo/Literata-72ptExtraBold.ufo">
       <location>
         <dimension name="Weight" xvalue="800"/>
         <dimension name="Optical size" xvalue="144"/>
@@ -652,7 +676,7 @@
         </dict>
       </lib>
     </instance>
-    <instance name="Literata 72pt Black" familyname="Literata" stylename="72pt Black" filename="instance_ufo/Literata-72ptBlack.ufo">
+    <instance name="Literata 72pt Black" familyname="Literata" stylename="72pt Black" stylemapfamilyname="72pt Black" stylemapstylename="regular" filename="instance_ufo/Literata-72ptBlack.ufo">
       <location>
         <dimension name="Weight" xvalue="900"/>
         <dimension name="Optical size" xvalue="144"/>
@@ -676,30 +700,6 @@
           <string>Medium (normal)</string>
         </dict>
       </lib>
-    </instance>
-    <instance name="Literata 12pt Medium" familyname="Literata" stylename="7pt Medium" filename="instance_ufo/Literata-7ptMedium.ufo">
-      <location>
-        <dimension name="Weight" xvalue="480"/>
-        <dimension name="Optical size" xvalue="6"/>
-      </location>
-      <kerning/>
-      <info/>
-    </instance>
-    <instance name="Literata 12pt Medium" familyname="Literata" stylename="36pt Medium" filename="instance_ufo/Literata-36ptMedium.ufo">
-      <location>
-        <dimension name="Weight" xvalue="480"/>
-        <dimension name="Optical size" xvalue="55"/>
-      </location>
-      <kerning/>
-      <info/>
-    </instance>
-    <instance name="Literata 12pt Medium" familyname="Literata" stylename="72pt Medium" filename="instance_ufo/Literata-72ptMedium.ufo">
-      <location>
-        <dimension name="Weight" xvalue="480"/>
-        <dimension name="Optical size" xvalue="144"/>
-      </location>
-      <kerning/>
-      <info/>
     </instance>
   </instances>
   <lib>


### PR DESCRIPTION
The instances in the existing .designspace files were missing styleMapFamilyName and styleMapStyleName attributes, causing each generated fonts to be the Regular style of its own style group.

Additionally, the medium weights were incorrectly labelled, with names and style names out of sync; they also lack a <lib> node.

These files have been manually edited to include the correct attributes, and the medium weights have been moved to their logical locations and provided with matching names and style names. The missing <lib> nodes have not been added.